### PR TITLE
Fix custom managed config URL handling

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -897,6 +897,14 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
         return "";
     }
 
+    if(!ext.general.empty())
+        for(auto &p : ext.general)
+        {
+            while(ini.item_exist("General", p.first))
+                ini.erase_first("General", p.first);
+            ini.set("General", p.first, p.second);
+        }
+
     ini.set_current_section("Proxy");
     ini.erase_section();
     ini.set("{NONAME}", "DIRECT = direct");
@@ -1636,6 +1644,14 @@ std::string proxyToQuanX(std::vector<Proxy> &nodes, const std::string &base_conf
         writeLog(0, "QuantumultX base loader failed with error: " + ini.get_last_error(), LOG_LEVEL_ERROR);
         return "";
     }
+
+    if(!ext.general.empty())
+        for(auto &p : ext.general)
+        {
+            while(ini.item_exist("general", p.first))
+                ini.erase_first("general", p.first);
+            ini.set("general", p.first, p.second);
+        }
 
     proxyToQuanX(nodes, ini, ruleset_content_array, extra_proxy_group, ext);
 

--- a/src/generator/config/subexport.h
+++ b/src/generator/config/subexport.h
@@ -34,6 +34,7 @@ struct extra_settings
     std::string managed_config_prefix;
     std::string managed_config_url;
     std::string quanx_dev_id;
+    string_map general;
     tribool udp = tribool();
     tribool tfo = tribool();
     tribool skip_cert_verify = tribool();

--- a/src/handler/interfaces.cpp
+++ b/src/handler/interfaces.cpp
@@ -478,7 +478,6 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
                     ext.enable_rule_generator = extconf.enable_rule_generator;
                     ext.overwrite_original_rules = extconf.overwrite_original_rules;
                     ext.embed_remote_rules = extconf.embed_remote_rules;
-                    ext.managed_config_url = extconf.managed_config_url;
                 }
             }
             if(!extconf.rename.empty())
@@ -491,6 +490,10 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
                 lExcludeRemarks = extconf.exclude;
             argAddEmoji.define(extconf.add_emoji);
             argRemoveEmoji.define(extconf.remove_old_emoji);
+            if(!extconf.managed_config_url.empty())
+                ext.managed_config_url = extconf.managed_config_url;
+            if(!extconf.general.empty())
+                ext.general = extconf.general;
         }
     }
     else
@@ -761,9 +764,12 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
     std::vector<RulesetContent> dummy_ruleset;
     std::string managed_url = base64Decode(getUrlArg(argument, "profile_data"));
     if(managed_url.empty())
-        managed_url = global.managedConfigPrefix + "/sub?" + joinArguments(argument);
-    if(managed_url.empty() && !ext.managed_config_url.empty())
-        managed_url = ext.managed_config_url;
+    {
+        if(!ext.managed_config_url.empty())
+            managed_url = ext.managed_config_url;
+        else if(!global.managedConfigPrefix.empty())
+            managed_url = global.managedConfigPrefix + "/sub?" + joinArguments(argument);
+    }
 
     //std::cerr<<"Generate target: ";
     proxy = parseProxy(global.proxyConfig);
@@ -821,7 +827,7 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
             if(argUpload)
                 uploadGist("surge" + argSurgeVer, argUploadPath, output_content, true);
 
-            if(global.writeManagedConfig && !global.managedConfigPrefix.empty())
+            if(global.writeManagedConfig && !managed_url.empty())
                 output_content = "#!MANAGED-CONFIG " + managed_url + (interval ? " interval=" + std::to_string(interval) : "") \
                  + " strict=" + std::string(strict ? "true" : "false") + "\n\n" + output_content;
         }
@@ -838,7 +844,7 @@ std::string subconverter(RESPONSE_CALLBACK_ARGS)
         if(argUpload)
             uploadGist("surfboard", argUploadPath, output_content, true);
 
-        if(global.writeManagedConfig && !global.managedConfigPrefix.empty())
+        if(global.writeManagedConfig && !managed_url.empty())
             output_content = "#!MANAGED-CONFIG " + managed_url + (interval ? " interval=" + std::to_string(interval) : "") \
                  + " strict=" + std::string(strict ? "true" : "false") + "\n\n" + output_content;
         break;

--- a/src/handler/settings.cpp
+++ b/src/handler/settings.cpp
@@ -1305,6 +1305,23 @@ int loadExternalConfig(std::string &path, ExternalConfig &ext)
     if(ini.item_prefix_exist("exclude_remarks"))
         ini.get_all("exclude_remarks", ext.exclude);
 
+    if(ini.section_exist("General"))
+    {
+        ini.enter_section("General");
+        string_multimap tempmap;
+        ini.get_items(tempmap);
+        for(auto &x : tempmap)
+            ext.general[x.first] = x.second;
+    }
+    else if(ini.section_exist("general"))
+    {
+        ini.enter_section("general");
+        string_multimap tempmap;
+        ini.get_items(tempmap);
+        for(auto &x : tempmap)
+            ext.general[x.first] = x.second;
+    }
+
     if(ini.section_exist("template") && ext.tpl_args != nullptr)
     {
         ini.enter_section("template");

--- a/src/handler/settings.h
+++ b/src/handler/settings.h
@@ -90,6 +90,7 @@ struct ExternalConfig
     RegexMatchConfigs emoji;
     string_array include;
     string_array exclude;
+    string_map general;
     template_args *tpl_args = nullptr;
     bool overwrite_original_rules = false;
     bool embed_remote_rules = false;


### PR DESCRIPTION
## Summary
- prioritize external `managed_config_url` over global prefix when building managed URL
- allow overriding `[General]` section values via external config for supported targets

## Testing
- `cmake .. && make -j$(nproc)` *(fails: Could not find a package configuration file provided by "toml11")*

------
https://chatgpt.com/codex/tasks/task_e_689772ab3648832d8557c58f61fac00d