### PR TITLE
Propagate ruleset flags into inlined and embedded rules

### DIFF
--- a/src/config/binding.h
+++ b/src/config/binding.h
@@ -285,21 +285,37 @@ namespace INIBinding
                 if(pos == String::npos)
                     continue;
                 conf.Group = x.substr(0, pos);
-                if(x.substr(pos + 1, 2) == "[]")
+                String rest = x.substr(pos + 1);
+                if(rest.substr(0, 2) == "[]")
                 {
-                    conf.Url = x.substr(pos + 1);
-                    //conf.Type = RulesetType::SurgeRuleset;
+                    conf.Url = rest;
                     confs.emplace_back(std::move(conf));
                     continue;
                 }
-                String::size_type epos = x.rfind(",");
-                if(pos != epos)
+                String::size_type fpos = rest.rfind(",flags=");
+                if(fpos != String::npos)
                 {
-                    conf.Interval = to_int(x.substr(epos + 1), 0);
-                    conf.Url = x.substr(pos + 1, epos - pos - 1);
+                    String flags_part = rest.substr(fpos + 7);
+                    String::size_type ipos = flags_part.find(',');
+                    if(ipos != String::npos)
+                    {
+                        conf.Interval = to_int(flags_part.substr(ipos + 1), 0);
+                        conf.Url = rest.substr(0, fpos) + ",flags=" + flags_part.substr(0, ipos);
+                    }
+                    else
+                        conf.Url = rest;
                 }
                 else
-                    conf.Url = x.substr(pos + 1);
+                {
+                    String::size_type epos = rest.rfind(",");
+                    if(epos != String::npos)
+                    {
+                        conf.Interval = to_int(rest.substr(epos + 1), 0);
+                        conf.Url = rest.substr(0, epos);
+                    }
+                    else
+                        conf.Url = rest;
+                }
                 confs.emplace_back(std::move(conf));
             }
             return confs;

--- a/src/generator/config/ruleconvert.cpp
+++ b/src/generator/config/ruleconvert.cpp
@@ -393,10 +393,12 @@ void rulesetToSurge(INIReader &base_rule, std::vector<RulesetContent> &ruleset_c
         std::string flags_a = extract_flags_from_tail(rule_path);
         std::string flags_b = extract_flags_from_tail(rule_path_typed);
         std::string merged_flags;
-        if(!flags_a.empty() && !flags_b.empty())
-            merged_flags = flags_b + "|" + flags_a;
-        else
-            merged_flags = !flags_b.empty() ? flags_b : flags_a;
+        if(!flags_b.empty())
+            merged_flags = flags_b;
+        if(!flags_a.empty())
+            merged_flags += (merged_flags.empty() ? "" : "|") + flags_a;
+        if(!x.flags.empty())
+            merged_flags += (merged_flags.empty() ? "" : "|") + x.flags;
 
         if(rule_path.empty())
         {

--- a/src/generator/config/ruleconvert.h
+++ b/src/generator/config/ruleconvert.h
@@ -24,6 +24,7 @@ struct RulesetContent
     std::string rule_group;
     std::string rule_path;
     std::string rule_path_typed;
+    std::string flags;
     int rule_type = RULESET_SURGE;
     std::shared_future<std::string> rule_content;
     int update_interval = 0;


### PR DESCRIPTION
## Summary
- preserve flags when parsing ruleset directives
- merge stored flags with legacy flag suffixes in Surge generator

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "toml11")*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bb75fec80832d87b396a7a48dcbf2