### PR TITLE
Add dns-server passthrough for Clash proxies

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -1174,6 +1174,8 @@ std::string proxyToSurge(std::vector<Proxy> &nodes, const std::string &base_conf
             continue;
         }
 
+        if(!x.DnsServers.empty())
+            proxy += ", dns-server=" + join(x.DnsServers, ",");
 
         if(!ext.tfo.is_undef())
             proxy += ", tfo=" + ext.tfo.get_str();

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1363,7 +1363,17 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             group = WG_DEFAULT_GROUP;
             singleproxy["public-key"] >>= public_key;
             singleproxy["private-key"] >>= private_key;
-            singleproxy["dns"] >>= dns_server;
+            auto dnsnode2 = singleproxy["dns"];
+            if(dnsnode2.IsSequence()){
+                string_array extra_dns;
+                dnsnode2 >>= extra_dns;
+                dns_server.insert(dns_server.end(), extra_dns.begin(), extra_dns.end());
+            } else {
+                std::string dns;
+                dnsnode2 >>= dns;
+                if(!dns.empty())
+                    dns_server.emplace_back(dns);
+            }
             singleproxy["mtu"] >>= mtu;
             singleproxy["preshared-key"] >>= password;
             singleproxy["ip"] >>= ip;

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1144,12 +1144,14 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
     for(uint32_t i = 0; i < yamlnode[section].size(); i++)
     {
         Proxy node;
+        dns_server.clear();
         singleproxy = yamlnode[section][i];
         singleproxy["type"] >>= proxytype;
         singleproxy["name"] >>= ps;
         singleproxy["server"] >>= server;
         singleproxy["port"] >>= port;
         singleproxy["interface-name"] >>= interface;
+        singleproxy["dns-server"] >>= dns_server;
         singleproxy["underlying-proxy"] >>= underlying_proxy;
         if((port.empty() || port == "0") && proxytype != "direct")
             continue;
@@ -1438,6 +1440,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
 
         node.Id = index;
         node.Interface = interface;
+        node.DnsServers = dns_server;
         nodes.emplace_back(std::move(node));
         index++;
     }

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1151,7 +1151,16 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
         singleproxy["server"] >>= server;
         singleproxy["port"] >>= port;
         singleproxy["interface-name"] >>= interface;
-        singleproxy["dns-server"] >>= dns_server;
+        auto dnsnode = singleproxy["dns-server"];
+        if(dnsnode.IsSequence())
+            dnsnode >>= dns_server;
+        else
+        {
+            std::string dns;
+            dnsnode >>= dns;
+            if(!dns.empty())
+                dns_server.emplace_back(dns);
+        }
         singleproxy["underlying-proxy"] >>= underlying_proxy;
         if((port.empty() || port == "0") && proxytype != "direct")
             continue;

--- a/src/parser/subparser.cpp
+++ b/src/parser/subparser.cpp
@@ -1359,7 +1359,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
 
             snellConstruct(node, group, ps, server, port, password, obfs, host, to_int(aid, 0), udp, tfo, scv, underlying_proxy);
             break;
-        case "wireguard"_hash:
+        case "wireguard"_hash: {
             group = WG_DEFAULT_GROUP;
             singleproxy["public-key"] >>= public_key;
             singleproxy["private-key"] >>= private_key;
@@ -1381,6 +1381,7 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
 
             wireguardConstruct(node, group, ps, server, port, ip, ipv6, private_key, public_key, password, dns_server, mtu, "0", "", "", udp, underlying_proxy);
             break;
+        }
         case "hysteria"_hash:
             group = HYSTERIA_DEFAULT_GROUP;
             singleproxy["ports"] >>= ports;
@@ -1452,7 +1453,6 @@ void explodeClash(Node yamlnode, std::vector<Proxy> &nodes)
             node.AllowInsecure = scv;
             node.UnderlyingProxy = underlying_proxy;
             break;
-    break;
         default:
             continue;
         }


### PR DESCRIPTION
## Summary
- support `dns-server` field when parsing Clash proxies
- include `dns-server` when exporting Surge proxy config

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "toml11")*

------
https://chatgpt.com/codex/tasks/task_e_68ac25dabc4c832d986fb7c6617c0d94